### PR TITLE
fixing flowUpdate.js

### DIFF
--- a/bin/flowUpdate.js
+++ b/bin/flowUpdate.js
@@ -2,9 +2,25 @@ const {client} = require('../twilioConstants');
 const flowObject = require('../twilioFlowObject');
 require('dotenv').config();
 
+console.log(process.env.FLOW_SID);
+//console.log(client);
+
 const update = 
     client.studio.flows(process.env.FLOW_SID)
-                 .update({commitMessage: 'update welcome redirect', definition: flowObject, status: 'published'})
+                 .update({commitMessage: 'update create list redirect', definition: flowObject, status: 'draft'})
                  .then(flow => console.log(flow.friendlyName));
+
+
+// debugging
+// console.log(update);
+// console.log(
+//     client.studio.flows(process.env.FLOW_SID)
+//                  .update({commitMessage: 'update create list redirect', definition: flowObject, status: 'published'})
+//                  .then(flow => console.log(flow))
+// );
+
+// client.studio.flows(process.env.FLOW_SID)
+//              .fetch()
+//              .then(flow => console.log(flow.friendlyName));
 
 module.exports = update;


### PR DESCRIPTION
the client.flow.update was set to 'published' instead of 'draft' so it didn't execute
does it need to be set to 'draft' first since values in the flow are being changed and the flow in my studio is in draft mode rn?
do I need to execute this function again but set to 'published'? (don't know if new flow values will be read by twilio if not)